### PR TITLE
fix bug of interpolate

### DIFF
--- a/huggingnft/lightweight_gan/lightweight_gan.py
+++ b/huggingnft/lightweight_gan/lightweight_gan.py
@@ -524,7 +524,7 @@ class Generator(nn.Module):
 
     def forward(self, x):
         x = rearrange(x, 'b c -> b c () ()')
-        x = self.initial_conv(x)
+        x = self.initial_conv(x.cpu())
         x = F.normalize(x, dim=1)
 
         residuals = dict()


### PR DESCRIPTION
The data is non CUDA, the model is loaded with `CPU`, that's why  the bug exists when using `model.generate_interpolation`.